### PR TITLE
Correction in the write function

### DIFF
--- a/src/File.cpp
+++ b/src/File.cpp
@@ -596,7 +596,7 @@ File::Type File::get_type()
 size_t File::write(const uint8_t *buffer, uint16_t size)
 {
     const uint8_t *src = buffer;
-    uint16_t written;
+    uint16_t written =0;
 
     if(!is_file() || !(flags & O_WRITE))
         return 0;
@@ -606,7 +606,7 @@ size_t File::write(const uint8_t *buffer, uint16_t size)
             return 0;
     }
 
-    for(written = 0; written < size; written++){
+    while (written < size){
         uint8_t boc = fs->get_block(current_position);
         uint16_t w_offset = current_position & 0x1FF;
 
@@ -684,7 +684,7 @@ size_t File::write(const uint8_t *buffer, uint16_t size)
         if(!sync())
             return 0;
     }
-    return written-1;
+    return written;
 }
 
 bool File::seek_end()


### PR DESCRIPTION
The FOR statement has a variable  written increased by 1 in each loop. This cause a problem when you write more than one block  in the flash memory, which cause to lost bytes during this process. 

The variable written must change its value only when a new data is write in the cache or in the flash memory. (line 673)