### PR TITLE
Fix library include

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,13 +28,13 @@
  */
 
 #include <avr/io.h>
-#include <serial.h>
-#include <SDCard.h>
-#include <FAT.h>
-#include <File.h>
-#include <SPI.h>
+#include "serial.h"
+#include "SDCard.h"
+#include "FAT.h"
+#include "File.h"
+#include "SPI.h"
 
-SDCard disk(&PORTB, &DDRB, PB2);
+SDCard disk(&PORTB, &DDRB, PB2); // Third parameter is the CS pin. (In this case PB2 is digital pin 10 in Arduino UNO)
 FAT fs(&disk);
 File root(&fs);
 File file(&fs);


### PR DESCRIPTION
If for some reason user does not copy the library to standard `include` path, it will cause an error:
```
fatal error: sd/SDCard.h: No such file or directory
#include <sd/SDCard.h>
                       ^
```

So I changed from `#include <SDCard.h>` to `#include "SDCard.h"` so it can be easier for new user.
Also, I added an note in `main.c` for CS pin.

Hope this be helpful. Thanks for the wonderful project!