### PR TITLE
Fix for #include

### DIFF
--- a/src/include/FAT.h
+++ b/src/include/FAT.h
@@ -30,8 +30,8 @@
 #ifndef _FAT_H_
 #define _FAT_H_
 
-#include <SDCard.h> // For now the only option
-#include <FatStructs.h>
+#include "SDCard.h" // For now the only option
+#include "FatStructs.h"
 
 union cache_t {
            /** Used to access cached file data blocks. */

--- a/src/include/File.h
+++ b/src/include/File.h
@@ -35,7 +35,7 @@
 #include <avr/pgmspace.h>
 #include <stdio.h>
 #include <ctype.h>
-#include <FAT.h>
+#include "FAT.h"
 
 class File {
 public:

--- a/src/include/SDCard.h
+++ b/src/include/SDCard.h
@@ -31,8 +31,8 @@
 #define _SDCARD_H_
 
 #include <stdint.h>
-#include <Millis.h>
-#include <SPI.h>
+#include "Millis.h"
+#include "SPI.h"
 
 class SDCard {
 public:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,13 +28,13 @@
  */
 
 #include <avr/io.h>
-#include <serial.h>
-#include <SDCard.h>
-#include <FAT.h>
-#include <File.h>
-#include <SPI.h>
+#include "serial.h"
+#include "SDCard.h"
+#include "FAT.h"
+#include "File.h"
+#include "SPI.h"
 
-SDCard disk(&PORTB, &DDRB, PB2);
+SDCard disk(&PORTB, &DDRB, PB2); // Third parameter is the CS pin. (In this case PB2 is digital pin 10 in Arduino UNO)
 FAT fs(&disk);
 File root(&fs);
 File file(&fs);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,10 +29,10 @@
 
 #include <avr/io.h>
 #include "serial.h"
-#include "SDCard.h"
-#include "FAT.h"
-#include "File.h"
-#include "SPI.h"
+#include "sd/include/SDCard.h"
+#include "sd/include/FAT.h"
+#include "sd/include/File.h"
+#include "sd/include/SPI.h"
 
 SDCard disk(&PORTB, &DDRB, PB2); // Third parameter is the CS pin. (In this case PB2 is digital pin 10 in Arduino UNO)
 FAT fs(&disk);


### PR DESCRIPTION
If for some reason user does not copy the library to standard `include` path, it will cause an error:
```
fatal error: sd/SDCard.h: No such file or directory
#include <sd/SDCard.h>
                       ^
```

So I changed from `#include <SDCard.h>` to `#include "SDCard.h"` so it can be easier for new user.
I also changed a lot of `#include` lines in files.
Also, I added an note in `main.c` for CS pin.

Hope this be helpful. Thanks for the wonderful project!